### PR TITLE
correction bug

### DIFF
--- a/src/Search/QueryBuilder.php
+++ b/src/Search/QueryBuilder.php
@@ -89,6 +89,10 @@ class QueryBuilder
 
         if (null !== $sortField) {
             $queryBuilder->orderBy(sprintf('%s%s', $isSortedByDoctrineAssociation ? '' : $queryBuilder->getRootAlias().'.', $sortField), $sortDirection);
+            if(isset($entityConfig['list']) && isset($entityConfig['list']['sort']) && isset($entityConfig['list']['sort']['field'])) {
+                $queryBuilder->addOrderBy(sprintf('%s%s',
+                    $isSortedByDoctrineAssociation ? '' : $queryBuilder->getRootAlias().'.', $entityConfig['list']['sort']['field']), 'ASC');
+            }
         }
 
         return $queryBuilder;


### PR DESCRIPTION
## Description

La dernière ligne d'une liste est dupliquée à la place de la première ligne de la seconde page. On perds donc une ligne. <br>

### Reproduction: 

* La cas intervenient lorsque les 2 lignes consécutives ont la même date. (les 2 dernières de la première page en l'occurence)
* Filtrer par ordre ASC un champ date 
* Regarder la dernière ligne, changer de page et constater la duplication sur la première ligne de la seconde page de la dernière ligne de la première page.


## Solution

Ajouter un order by en se basant sur la config si elle existe.
