### PR TITLE
suppresion flash message (cause erreur test)

### DIFF
--- a/src/Filter/FilterType/DateFilterType.php
+++ b/src/Filter/FilterType/DateFilterType.php
@@ -4,10 +4,7 @@ namespace Lle\EasyAdminPlusBundle\Filter\FilterType;
 
 use DateTime;
 
-use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * DateFilterType

--- a/src/Filter/FilterType/DateFilterType.php
+++ b/src/Filter/FilterType/DateFilterType.php
@@ -17,15 +17,6 @@ class DateFilterType extends AbstractFilterType
 
     protected $yearRange;
 
-    protected $flashBag;
-
-    protected $translator;
-
-    public function __construct(SessionInterface $session, TranslatorInterface $translator)
-    {
-        $this->flashBag = $session->getFlashBag();
-        $this->translator = $translator;
-    }
 
     public function configure(array $config = [])
     {
@@ -55,7 +46,6 @@ class DateFilterType extends AbstractFilterType
 
             $date = DateTime::createFromFormat('d/m/Y', $this->data['value']);
             if (!$date) {
-                $this->flashBag->add("error nt", $this->translator->trans('filter.dateFilter.wrong_format', [], 'EasyAdminPlusBundle'));
                 return false;
             }
 

--- a/src/Filter/FilterType/PeriodeFilterType.php
+++ b/src/Filter/FilterType/PeriodeFilterType.php
@@ -18,15 +18,6 @@ class PeriodeFilterType extends AbstractFilterType
     private $requestChoice;
     private $format;
 
-    protected $flashBag;
-
-    protected $translator;
-
-    public function __construct(SessionInterface $session, TranslatorInterface $translator)
-    {
-        $this->flashBag = $session->getFlashBag();
-        $this->translator = $translator;
-    }
 
     public function configure(array $config = [])
     {
@@ -45,12 +36,9 @@ class PeriodeFilterType extends AbstractFilterType
             $qb = $queryBuilder;
             $from = $to = null;
             $c = $this->alias . $this->columnName;
-            $error = false;
             if(isset($this->data['value']['from']) && $this->data['value']['from']) {
                 $from = DateTime::createFromFormat($this->format, $this->data['value']['from']);
-                if (!$from) {
-                    $error = true;
-                } else {
+                if ($from) {
                     $from = $from->format('Y-m-d');
                     $qb->andWhere($c. ' >= :var_from_' . $this->uniqueId);
                     $queryBuilder->setParameter('var_from_' . $this->uniqueId, $from);
@@ -58,17 +46,12 @@ class PeriodeFilterType extends AbstractFilterType
             }
             if(isset($this->data['value']['to']) && $this->data['value']['to']) {
                 $to = DateTime::createFromFormat($this->format, $this->data['value']['to']);
-                if (!$to) {
-                    $error = true;
-                } else {
+                if ($to) {
                     $to->modify('+1 day');
                     $to = $to->format('Y-m-d');
                     $qb->andWhere($c.' < :var_to_'.$this->uniqueId);
                     $queryBuilder->setParameter('var_to_' . $this->uniqueId, $to);
                 }
-            }
-            if ($error) {
-                $this->flashBag->add("error nt", $this->translator->trans('filter.dateFilter.wrong_format', [], 'EasyAdminPlusBundle'));
             }
         }
     }

--- a/src/Filter/FilterType/PeriodeFilterType.php
+++ b/src/Filter/FilterType/PeriodeFilterType.php
@@ -5,8 +5,6 @@ namespace Lle\EasyAdminPlusBundle\Filter\FilterType;
 use DateTime;
 
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * DateFilterType

--- a/src/Resources/translations/EasyAdminPlusBundle.en.yaml
+++ b/src/Resources/translations/EasyAdminPlusBundle.en.yaml
@@ -124,6 +124,3 @@ Réinitialiser: Reset
 Actions massives: Batch actions
 Filtrer les résultats: Filter results
 form.url_auto_complet.placeholder: Choose a value
-filter:
-    dateFilter:
-        wrong_format: Wrong date format for the date filter

--- a/src/Resources/translations/EasyAdminPlusBundle.fr.yaml
+++ b/src/Resources/translations/EasyAdminPlusBundle.fr.yaml
@@ -133,6 +133,3 @@ Réinitialiser: Réinitialiser
 Actions massives: Actions massives
 Filtrer les résultats: Filtrer les résultats
 form.url_auto_complet.placeholder: Choisir une valeur
-filter:
-    dateFilter:
-        wrong_format: Mauvais format de date pour le filtre date


### PR DESCRIPTION
L'injection de la session dans les filtres faisait planter les tests (??)

Erreur:
``` 
cannot set session id after the session has started
```