### PR TITLE
Filter correction

### DIFF
--- a/src/Filter/FilterType/AbstractFilterType.php
+++ b/src/Filter/FilterType/AbstractFilterType.php
@@ -99,6 +99,8 @@ abstract class AbstractFilterType implements FilterTypeInterface
                 $val_post = $request->request->get($var, null);
                 if (! is_null($val_post)) {
                     $this->data[$k] = $val_post;
+                } else {
+                    $this->data = [];
                 }
             }
         }

--- a/src/Filter/FilterType/StringFilterType.php
+++ b/src/Filter/FilterType/StringFilterType.php
@@ -33,7 +33,7 @@ class StringFilterType extends AbstractFilterType
         parent::configure($config);
         $this->defaults = [
             'value' => $config['defaultValue'] ?? "",
-            'comparator' => $config['defaultComparator'] ?? "startswith"
+            'comparator' => $config['defaultComparator'] ?? "contains"
         ];
         $this->additionalProperties = $config['additionalProperties'] ?? [];
         


### PR DESCRIPTION
- Default value "contains" for string filter
- The cross to remove filters wasn't working, now if the value is null the data filter array is empty (nothing was done before)