### PR TITLE
Confirm modal max lines export

### DIFF
--- a/src/Resources/translations/EasyAdminPlusBundle.en.yaml
+++ b/src/Resources/translations/EasyAdminPlusBundle.en.yaml
@@ -107,6 +107,7 @@ batch:
     execute: Execute
 label.batchthispage: "This page"
 action.batchselectall: "Select all"
+action.export.confirm.maxLines: "There are more than %max% lines that will be exported, do you want to continue ?"
 label.batchallselectactive: "All items are selected"
 action.batchselectpage: "Select current page"
 label.batchselectall: "Select all"

--- a/src/Resources/translations/EasyAdminPlusBundle.fr.yaml
+++ b/src/Resources/translations/EasyAdminPlusBundle.fr.yaml
@@ -108,6 +108,7 @@ batch:
 label.batchthispage: "Uniquement sur la page courante"
 label.batchallpage: "Sur toutes les pages"
 action.batchselectall: "Tout sélectionner"
+action.export.confirm.maxLines: "Il y a plus de %max% lignes qui vont êtres exportées, voulez vous continuer ?"
 label.batchallselectactive: "Appliqué à tout"
 action.batchselectpage: "Sélectionner la page affichée"
 label.batchselectall: "Sélectionner tout"

--- a/src/Resources/views/default/list.html.twig
+++ b/src/Resources/views/default/list.html.twig
@@ -77,8 +77,8 @@
                 {%  for format in _entity_config.export.formats %}
                         <a class="btn btn-primary"
                                 {% if _entity_config.export.max is defined and paginator.nbResults > _entity_config.export.max %}
-                                onclick="confirmExport('{{ path('easyadmin', app.request.query|merge({ action: "export", format: format })) }}',
-                                        '{{ 'easyadminplus_confirm_export_moreLinesThan_max' | trans({'%max%': paginator.nbResults}) }}')"
+                                    {% set message =  'action.export.confirm.maxLines' | trans({'%max%': paginator.nbResults}, 'EasyAdminPlusBundle') %}
+                                    onclick="confirmExport('{{ path('easyadmin', app.request.query|merge({ action: "export", format: format })) }}','{{ message }}')"
                                 {% else %}
                                     href="{{ path('easyadmin', app.request.query|merge({ action: "export", format: format })) }}"
                                  {% endif %}

--- a/src/Resources/views/default/list.html.twig
+++ b/src/Resources/views/default/list.html.twig
@@ -15,27 +15,6 @@
     {% block filters %}
         {{ include('@LleEasyAdminPlus/default/includes/_filters.html.twig') }}
     {% endblock %}
-    {% block confirmModal %}
-        <div class="modal fade" id="easyadminplus-confirmModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
-            <div class="modal-dialog" role="document">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <h5 class="modal-title" id="easyadminplus-confirmModal-title"> Confirm </h5>
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
-                    </div>
-                    <div class="modal-body" id="easyadminplus-confirmModal-body">
-                        {{ 'easyadminplus_confirm_export_moreLinesThan_max' | trans({'%max%': paginator.nbResults}) }}
-                    </div>
-                    <div class="modal-footer">
-                        <a type="button" class="btn btn-secondary" data-dismiss="modal">Close</a>
-                        <a type="button" class="btn btn-primary" onclick="$('#easyadminplus-confirmModal').modal('hide')" id="easyadminplus-btn-confirm">Confirm</a>
-                    </div>
-                </div>
-            </div>
-        </div>
-    {% endblock %}
 {% endblock %}
 
 
@@ -96,17 +75,17 @@
             {% if _entity_config.export is defined and is_easyadmin_granted(_entity_config, 'export', null) %}
                 {% set referer = app.request.server.get('http-referer')|default('/') %}
                 {%  for format in _entity_config.export.formats %}
-                    {% if _entity_config.export.max is defined and paginator.nbResults > _entity_config.export.max %}
-                        <a class="btn btn-primary" onclick="confirmModal('{{ path('easyadmin', app.request.query|merge({ action: "export", format: format })) }}', 'test')" style="margin-right:5px;" >
+                        <a class="btn btn-primary"
+                                {% if _entity_config.export.max is defined and paginator.nbResults > _entity_config.export.max %}
+                                onclick="confirmExport('{{ path('easyadmin', app.request.query|merge({ action: "export", format: format })) }}',
+                                        '{{ 'easyadminplus_confirm_export_moreLinesThan_max' | trans({'%max%': paginator.nbResults}) }}')"
+                                {% else %}
+                                    href="{{ path('easyadmin', app.request.query|merge({ action: "export", format: format })) }}"
+                                 {% endif %}
+                           style="margin-right:5px;" >
                             <i class="fa fa-download"></i>
                             {{ 'exporter.export'|trans({'%format%':format}, 'EasyAdminPlusBundle') }}
                         </a>
-                    {% else %}
-                        <a class="btn btn-primary" style="margin-right:5px;" href="{{ path('easyadmin', app.request.query|merge({ action: "export", format: format })) }}">
-                            <i class="fa fa-download"></i>
-                            {{ 'exporter.export'|trans({'%format%':format}, 'EasyAdminPlusBundle') }}
-                        </a>
-                    {% endif %}
                 {%  endfor %}
             {% endif %}
 
@@ -229,9 +208,11 @@
             }
         }
 
-        function confirmModal(url) {
-            $('#easyadminplus-confirmModal').modal('show')
-            $('#easyadminplus-btn-confirm').attr("href", url)
+        function confirmExport(url, message) {
+            let res = window.confirm(message)
+            if (res) {
+                document.location.href = url
+            }
         }
 
     </script>

--- a/src/Resources/views/default/list.html.twig
+++ b/src/Resources/views/default/list.html.twig
@@ -15,7 +15,27 @@
     {% block filters %}
         {{ include('@LleEasyAdminPlus/default/includes/_filters.html.twig') }}
     {% endblock %}
-
+    {% block confirmModal %}
+        <div class="modal fade" id="easyadminplus-confirmModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+            <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="easyadminplus-confirmModal-title"> Confirm </h5>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+                    <div class="modal-body" id="easyadminplus-confirmModal-body">
+                        {{ 'easyadminplus_confirm_export_moreLinesThan_max' | trans({'%max%': paginator.nbResults}) }}
+                    </div>
+                    <div class="modal-footer">
+                        <a type="button" class="btn btn-secondary" data-dismiss="modal">Close</a>
+                        <a type="button" class="btn btn-primary" onclick="$('#easyadminplus-confirmModal').modal('hide')" id="easyadminplus-btn-confirm">Confirm</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    {% endblock %}
 {% endblock %}
 
 
@@ -27,7 +47,7 @@
             {% set _list_item_actions = _list_item_actions|prune_item_actions(_entity_config, [], null) %}
             {% for action in _list_item_actions if (action.global is defined and action.global) %}
                     {%  if action.confirm is defined %}
-                        {%  if action.route is defined %}
+                        {% if action.route is defined %}
                             {% set action_href = path(action.route, action.parameters) %}
                         {% else %}
                             {% set action_href = path(action.name, action.parameters) %}
@@ -71,14 +91,22 @@
                     {% endif %}
             {% endfor %}
 
+
             {# EXPORT #}
             {% if _entity_config.export is defined and is_easyadmin_granted(_entity_config, 'export', null) %}
                 {% set referer = app.request.server.get('http-referer')|default('/') %}
                 {%  for format in _entity_config.export.formats %}
-                    <a class="btn btn-primary" style="margin-right:5px;" href="{{ path('easyadmin', app.request.query|merge({ action: "export", format: format })) }}">
-                        <i class="fa fa-download"></i>
-                        {{ 'exporter.export'|trans({'%format%':format}, 'EasyAdminPlusBundle') }}
-                    </a>
+                    {% if _entity_config.export.max is defined and paginator.nbResults > _entity_config.export.max %}
+                        <a class="btn btn-primary" onclick="confirmModal('{{ path('easyadmin', app.request.query|merge({ action: "export", format: format })) }}', 'test')" style="margin-right:5px;" >
+                            <i class="fa fa-download"></i>
+                            {{ 'exporter.export'|trans({'%format%':format}, 'EasyAdminPlusBundle') }}
+                        </a>
+                    {% else %}
+                        <a class="btn btn-primary" style="margin-right:5px;" href="{{ path('easyadmin', app.request.query|merge({ action: "export", format: format })) }}">
+                            <i class="fa fa-download"></i>
+                            {{ 'exporter.export'|trans({'%format%':format}, 'EasyAdminPlusBundle') }}
+                        </a>
+                    {% endif %}
                 {%  endfor %}
             {% endif %}
 
@@ -199,6 +227,11 @@
                 if (val) $(id_button + ' .'+val).show();
                 return false;
             }
+        }
+
+        function confirmModal(url) {
+            $('#easyadminplus-confirmModal').modal('show')
+            $('#easyadminplus-btn-confirm').attr("href", url)
         }
 
     </script>

--- a/src/Resources/views/default/list.html.twig
+++ b/src/Resources/views/default/list.html.twig
@@ -78,10 +78,9 @@
                         <a class="btn btn-primary"
                                 {% if _entity_config.export.max is defined and paginator.nbResults > _entity_config.export.max %}
                                     {% set message =  'action.export.confirm.maxLines' | trans({'%max%': paginator.nbResults}, 'EasyAdminPlusBundle') %}
-                                    onclick="confirmExport('{{ path('easyadmin', app.request.query|merge({ action: "export", format: format })) }}','{{ message }}')"
-                                {% else %}
-                                    href="{{ path('easyadmin', app.request.query|merge({ action: "export", format: format })) }}"
+                                    onclick="return confirmExport('{{ path('easyadmin', app.request.query|merge({ action: "export", format: format })) }}','{{ message }}')"
                                  {% endif %}
+                           href="{{ path('easyadmin', app.request.query|merge({ action: "export", format: format })) }}"
                            style="margin-right:5px;" >
                             <i class="fa fa-download"></i>
                             {{ 'exporter.export'|trans({'%format%':format}, 'EasyAdminPlusBundle') }}
@@ -209,10 +208,7 @@
         }
 
         function confirmExport(url, message) {
-            let res = window.confirm(message)
-            if (res) {
-                document.location.href = url
-            }
+            return window.confirm(message)
         }
 
     </script>


### PR DESCRIPTION
Ajout d'un clé "max" dans la config de l'export qui permet de faire apparaitre une modal de confirmation si le nombre de lignes total dépasse la valeur de max.

Exemple:
```
            export:
                formats: ['xlsx']
                max: 500
                fields:
                    - ...
```

